### PR TITLE
Update scipy link

### DIFF
--- a/intersphinx_registry/registry.json
+++ b/intersphinx_registry/registry.json
@@ -135,7 +135,7 @@
   "rtd": ["https://docs.readthedocs.io/en/stable/", null],
   "rtd-dev": ["https://dev.readthedocs.io/en/latest/", null],
   "scanpy": ["https://scanpy.readthedocs.io/en/stable/", null],
-  "scipy": ["https://docs.scipy.org/doc/scipy/reference/", null],
+  "scipy": ["https://docs.scipy.org/doc/scipy/", null],
   "scipy-lecture-notes": ["https://scipy-lectures.org/", null],
   "scriptconfig": ["https://scriptconfig.readthedocs.io/en/latest/", null],
   "seaborn": ["https://seaborn.pydata.org/", null],


### PR DESCRIPTION
sphinx build yields

> intersphinx inventory has moved: https://docs.scipy.org/doc/scipy/reference/objects.inv -> https://docs.scipy.org/doc/scipy/objects.inv