### PR TITLE
API: make filtering the included packages the encouraged behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ link only to _stable_ package, not dev versions.
 ## A package is missing !
 
 We can't do all packages, but if you think a package is widely used and missing,
-please send an PR.
+please send a PR.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Usage in `conf.py`
 from intersphinx_registry import get_intersphinx_mapping
 
 # ...
-
-intersphinx_mapping = get_intersphinx_mapping()
+intersphinx_mapping = get_intersphinx_mapping(
+    only={"ipython", "matplotlib", "pandas", "python"}
+)
 intersphinx_mapping.update({
     'overwrite': ('<url>', None),
     'my-package' : ('<url>', None),
@@ -17,7 +18,7 @@ intersphinx_mapping.update({
 ```
 
 
-## Why ? 
+## Why ?
 
 Sometime packages docs move and it's hard to keep track of. We _try_ to keep the
 registry up to date, so yo do not have to ask yourself questions and update your
@@ -34,14 +35,4 @@ link only to _stable_ package, not dev versions.
 ## A package is missing !
 
 We can't do all packages, but if you think a package is widely used and missing,
-please send an PR. 
-
-
-
-
-
-
-
-
-
-
+please send an PR.

--- a/intersphinx_registry/__init__.py
+++ b/intersphinx_registry/__init__.py
@@ -16,20 +16,23 @@ registry_file = Path(__file__).parent / "registry.json"
 
 
 def get_intersphinx_mapping(
-    *, only: Optional[Set[str]] = None
+    *, only: Optional[Set[str]]
 ) -> Dict[str, Tuple[str, Optional[str]]]:
     """
     Return values of intersphinx_mapping for sphinx configuration.
 
-    For convenience, the return dict is a copy so should be ok to mutate
+    For convenience, the returned dictionary is a copy so should be ok to
+    mutate.
 
     Parameters
     ----------
-    only: Set of Str
-        list of libraries to include.
-        This is purely for optimisation as sphinx may download and load all the
-        `objects.inv` listed, in get_intersphinx_mapping. This let users reduce
-        the number of requested files.
+    only: Set of Str or None
+        Libraries to include.
+
+        Sphinx will download and load all the `objects.inv` listed in
+        intersphinx_mapping.  To get all known libraries explicitly pass
+        `None`.
+
     """
     mapping = cast(
         Dict[str, Tuple[str, Optional[str]]],

--- a/intersphinx_registry/__init__.py
+++ b/intersphinx_registry/__init__.py
@@ -41,10 +41,10 @@ def get_intersphinx_mapping(
 
     """
     if len(packages) == 0:
-        raise ValueError('You now must explicitly give a list of package to download inter sphinx from: get_intersphinx_mapping(["IPython", "numpy",...]).')
+        raise ValueError('You must explicitly give a list of packages for which to download intersphinx inventories: get_intersphinx_mapping(packages=["IPython", "numpy",...]).')
 
     mapping = _get_all_mappings()
     missing = set(packages) - set(mapping)
     if missing:
-        raise ValueError(f"Missing libraries in 'packages': {repr(sorted(missing))}")
+        raise ValueError(f"Some libraries in 'packages' not found in registry: {repr(sorted(missing))}")
     return {k: v for k, v in mapping.items() if k in packages}

--- a/intersphinx_registry/registry.json
+++ b/intersphinx_registry/registry.json
@@ -1,6 +1,6 @@
 {
-  "Pillow": ["https://pillow.readthedocs.io/en/stable/", null],
-  "PyPUG": ["https://packaging.python.org/en/latest/", null],
+  "pillow": ["https://pillow.readthedocs.io/en/stable/", null],
+  "pypug": ["https://packaging.python.org/en/latest/", null],
   "anndata": ["https://anndata.readthedocs.io/en/stable/", null],
   "asdf-astropy": ["https://asdf-astropy.readthedocs.io/en/latest/", null],
   "astropy-dev": ["https://docs.astropy.org/en/latest/", null],

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,8 +1,8 @@
-from intersphinx_registry import get_intersphinx_mapping
+from intersphinx_registry import _get_all_mappings, get_intersphinx_mapping
 import pytest
 import requests
 
-MAPPING = get_intersphinx_mapping()
+MAPPING = _get_all_mappings()
 keys = set(MAPPING.keys())
 
 
@@ -27,5 +27,15 @@ def test_reach_objects_inv(key: str):
 
 
 def test_bad():
-    with pytest.raises(ValueError, match="Missing libraries"):
-        get_intersphinx_mapping(only={"-nonexistent-"})
+    with pytest.raises(ValueError, match="Some libraries in"):
+        get_intersphinx_mapping(packages={"-nonexistent-"})
+
+
+@pytest.mark.parametrize('key', sorted(keys))
+def test_lower_case(key):
+    """
+    We agreed that all keys in the mapping should be lower case
+    """
+    assert key == key.lower(), 'expecting all keys to be lowercase'
+
+


### PR DESCRIPTION
I think defaulting to expecting a list is good because:

 - limits needless downloads (it is only 3-4M pre run, but that will add up quickly)
 - makes it easy to see in `conf.py` what external links _should_ work

The con is that it is a bit more verbose, but still an improvement over every project maintaining the urls.